### PR TITLE
Enforce TLS for PostgreSQL connections by default

### DIFF
--- a/cmd/functions/db/changepassword.go
+++ b/cmd/functions/db/changepassword.go
@@ -45,7 +45,7 @@ func runChangePassword(cmd *cobra.Command, args []string) {
 	switch profile.DbType {
 	case "psql":
 		dbPort, _ := strconv.Atoi(profile.Port)
-		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database)
+		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode)
 		psql.ChangeUserPassword(username, newPassword)
 		psql.Close()
 	case "mysql":

--- a/cmd/functions/db/createdatabase.go
+++ b/cmd/functions/db/createdatabase.go
@@ -42,7 +42,7 @@ func runCreateDatabase(cmd *cobra.Command, args []string) {
 	switch profile.DbType {
 	case "psql":
 		dbPort, _ := strconv.Atoi(profile.Port)
-		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database)
+		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode)
 		psql.CreateDatabase(database)
 		psql.Close()
 	case "mysql":

--- a/cmd/functions/db/createuser.go
+++ b/cmd/functions/db/createuser.go
@@ -44,7 +44,7 @@ func runCreateUser(cmd *cobra.Command, args []string) {
 	switch profile.DbType {
 	case "psql":
 		dbPort, _ := strconv.Atoi(profile.Port)
-		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database)
+		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode)
 		psql.CreateUser(username, password)
 		psql.Close()
 	case "mysql":

--- a/cmd/functions/db/deletedatabase.go
+++ b/cmd/functions/db/deletedatabase.go
@@ -42,7 +42,7 @@ func runDeleteDatabase(cmd *cobra.Command, args []string) {
 	switch profile.DbType {
 	case "psql":
 		dbPort, _ := strconv.Atoi(profile.Port)
-		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database)
+		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode)
 		psql.DeleteDatabase(database)
 		psql.Close()
 	case "mysql":

--- a/cmd/functions/db/deleteuser.go
+++ b/cmd/functions/db/deleteuser.go
@@ -42,7 +42,7 @@ func runDeleteUser(cmd *cobra.Command, args []string) {
 	switch profile.DbType {
 	case "psql":
 		dbPort, _ := strconv.Atoi(profile.Port)
-		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database)
+		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode)
 		psql.DeleteUser(username)
 		psql.Close()
 	case "mysql":

--- a/cmd/functions/db/exec.go
+++ b/cmd/functions/db/exec.go
@@ -51,7 +51,7 @@ func runExecCommand(cmd *cobra.Command, args []string) {
 		switch profile.DbType {
 		case "psql":
 			dbPort, _ := strconv.Atoi(profile.Port)
-			psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database)
+			psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode)
 			psql.FileExec(file)
 			psql.Close()
 		case "mysql":
@@ -63,7 +63,7 @@ func runExecCommand(cmd *cobra.Command, args []string) {
 		switch profile.DbType {
 		case "psql":
 			dbPort, _ := strconv.Atoi(profile.Port)
-			psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database)
+			psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode)
 			psql.Exec(query)
 			psql.Close()
 		case "mysql":

--- a/cmd/functions/db/grantdatabase.go
+++ b/cmd/functions/db/grantdatabase.go
@@ -52,7 +52,7 @@ func runGrantDatabase(cmd *cobra.Command, args []string) {
 	switch profile.DbType {
 	case "psql":
 		dbPort, _ := strconv.Atoi(profile.Port)
-		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database)
+		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode)
 		psql.GrantPermissions(database, username, permission)
 		psql.Close()
 	case "mysql":

--- a/cmd/functions/db/granttable.go
+++ b/cmd/functions/db/granttable.go
@@ -52,7 +52,7 @@ func runGrantTable(cmd *cobra.Command, args []string) {
 	switch profile.DbType {
 	case "psql":
 		dbPort, _ := strconv.Atoi(profile.Port)
-		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database)
+		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode)
 		psql.GrantTablePermissions(table, username, permission)
 		psql.Close()
 	case "mysql":

--- a/cmd/functions/db/listdatabases.go
+++ b/cmd/functions/db/listdatabases.go
@@ -33,7 +33,7 @@ func runListDatabases(cmd *cobra.Command, args []string) {
 	switch profile.DbType {
 	case "psql":
 		dbPort, _ := strconv.Atoi(profile.Port)
-		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database)
+		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode)
 		psql.ListDatabases()
 		psql.Close()
 	case "mysql":

--- a/cmd/functions/db/listtables.go
+++ b/cmd/functions/db/listtables.go
@@ -33,7 +33,7 @@ func runListTables(cmd *cobra.Command, args []string) {
 	switch profile.DbType {
 	case "psql":
 		dbPort, _ := strconv.Atoi(profile.Port)
-		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database)
+		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode)
 		psql.ListTables()
 		psql.Close()
 	case "mysql":

--- a/cmd/functions/db/listusers.go
+++ b/cmd/functions/db/listusers.go
@@ -33,7 +33,7 @@ func runListUsers(cmd *cobra.Command, args []string) {
 	switch profile.DbType {
 	case "psql":
 		dbPort, _ := strconv.Atoi(profile.Port)
-		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database)
+		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode)
 		psql.ListUsers()
 		psql.Close()
 	case "mysql":

--- a/cmd/functions/db/ping.go
+++ b/cmd/functions/db/ping.go
@@ -33,7 +33,7 @@ func runPingDatabase(cmd *cobra.Command, args []string) {
 	switch profile.DbType {
 	case "psql":
 		dbPort, _ := strconv.Atoi(profile.Port)
-		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database)
+		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode)
 		psql.Ping()
 		psql.Close()
 	case "mysql":

--- a/cmd/functions/db/revokedatabase.go
+++ b/cmd/functions/db/revokedatabase.go
@@ -52,7 +52,7 @@ func runRevokeDatabase(cmd *cobra.Command, args []string) {
 	switch profile.DbType {
 	case "psql":
 		dbPort, _ := strconv.Atoi(profile.Port)
-		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database)
+		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode)
 		psql.RevokePermissions(database, username, permission)
 		psql.Close()
 	case "mysql":

--- a/cmd/functions/db/revoketable.go
+++ b/cmd/functions/db/revoketable.go
@@ -52,7 +52,7 @@ func runRevokeTable(cmd *cobra.Command, args []string) {
 	switch profile.DbType {
 	case "psql":
 		dbPort, _ := strconv.Atoi(profile.Port)
-		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database)
+		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode)
 		psql.RevokeTablePermissions(table, username, permission)
 		psql.Close()
 	case "mysql":

--- a/cmd/functions/profile/add.go
+++ b/cmd/functions/profile/add.go
@@ -32,6 +32,7 @@ dbac profile add --file mysql-profile.yml
 	cmd.Flags().String("host", "", "Host of the database")
 	cmd.Flags().String("port", "", "Port of the database")
 	cmd.Flags().String("database", "", "Name of the database")
+	cmd.Flags().String("ssl-mode", "", "PostgreSQL SSL mode (disable, allow, prefer, require, verify-ca, verify-full); defaults to require")
 	cmd.Flags().StringP("file", "f", "", "Path to the YAML file containing the profile details")
 
 	subcommand.AddCommand(cmd)
@@ -78,6 +79,7 @@ func runAddProfile(cmd *cobra.Command, args []string) {
 		host, _ := cmd.Flags().GetString("host")
 		port, _ := cmd.Flags().GetString("port")
 		database, _ := cmd.Flags().GetString("database")
+		sslmode, _ := cmd.Flags().GetString("ssl-mode")
 
 		if err := helper.StorePassword(name, password); err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to store password in keychain: %v\n", err)
@@ -92,6 +94,7 @@ func runAddProfile(cmd *cobra.Command, args []string) {
 			Database: database,
 			Port:     port,
 			Name:     name,
+			SSLMode:  sslmode,
 		}
 
 		var allProfiles helper.Profiles

--- a/cmd/helper/batch.go
+++ b/cmd/helper/batch.go
@@ -211,7 +211,7 @@ func App(param string, step int, file string) {
 		if currentProfile.DbType == "psql" {
 			db_port, _ := strconv.Atoi(currentProfile.Port)
 
-			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database)
+			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode)
 			psql.CreateUser(stepper.Steps[step].Username, stepper.Steps[step].Password)
 			psql.Close()
 		} else if currentProfile.DbType == "mysql" {
@@ -241,7 +241,7 @@ func App(param string, step int, file string) {
 		if currentProfile.DbType == "psql" {
 			db_port, _ := strconv.Atoi(currentProfile.Port)
 
-			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database)
+			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode)
 			psql.CreateDatabase(stepper.Steps[step].Database)
 			psql.Close()
 		} else if currentProfile.DbType == "mysql" {
@@ -270,7 +270,7 @@ func App(param string, step int, file string) {
 
 		if currentProfile.DbType == "psql" {
 			db_port, _ := strconv.Atoi(currentProfile.Port)
-			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database)
+			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode)
 			psql.GrantPermissions(stepper.Steps[step].Database, stepper.Steps[step].Username, stepper.Steps[step].Permission)
 			psql.Close()
 		} else if currentProfile.DbType == "mysql" {
@@ -299,7 +299,7 @@ func App(param string, step int, file string) {
 
 		if currentProfile.DbType == "psql" {
 			db_port, _ := strconv.Atoi(currentProfile.Port)
-			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database)
+			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode)
 			psql.ChangeUserPassword(stepper.Steps[step].Username, stepper.Steps[step].NewPassword)
 			psql.Close()
 		} else if currentProfile.DbType == "mysql" {
@@ -328,7 +328,7 @@ func App(param string, step int, file string) {
 
 		if currentProfile.DbType == "psql" {
 			db_port, _ := strconv.Atoi(currentProfile.Port)
-			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database)
+			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode)
 			psql.RevokePermissions(stepper.Steps[step].Database, stepper.Steps[step].Username, stepper.Steps[step].Permission)
 			psql.Close()
 		} else if currentProfile.DbType == "mysql" {
@@ -357,7 +357,7 @@ func App(param string, step int, file string) {
 
 		if currentProfile.DbType == "psql" {
 			db_port, _ := strconv.Atoi(currentProfile.Port)
-			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database)
+			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode)
 			psql.DeleteUser(stepper.Steps[step].Username)
 			psql.Close()
 		} else if currentProfile.DbType == "mysql" {
@@ -386,7 +386,7 @@ func App(param string, step int, file string) {
 
 		if currentProfile.DbType == "psql" {
 			db_port, _ := strconv.Atoi(currentProfile.Port)
-			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database)
+			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode)
 			psql.DeleteDatabase(stepper.Steps[step].Database)
 			psql.Close()
 		} else if currentProfile.DbType == "mysql" {
@@ -415,7 +415,7 @@ func App(param string, step int, file string) {
 		if stepper.Steps[step].File == "" {
 			if currentProfile.DbType == "psql" {
 				db_port, _ := strconv.Atoi(currentProfile.Port)
-				psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database)
+				psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode)
 				psql.Exec(stepper.Steps[step].Query)
 				psql.Close()
 			} else if currentProfile.DbType == "mysql" {
@@ -426,7 +426,7 @@ func App(param string, step int, file string) {
 		} else {
 			if currentProfile.DbType == "psql" {
 				db_port, _ := strconv.Atoi(currentProfile.Port)
-				psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database)
+				psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode)
 				psql.FileExec(stepper.Steps[step].File)
 				psql.Close()
 			} else if currentProfile.DbType == "mysql" {
@@ -457,7 +457,7 @@ func App(param string, step int, file string) {
 
 		if currentProfile.DbType == "psql" {
 			db_port, _ := strconv.Atoi(currentProfile.Port)
-			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database)
+			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode)
 			psql.RevokeTablePermissions(stepper.Steps[step].Table, stepper.Steps[step].Username, stepper.Steps[step].Permission)
 			psql.Close()
 		} else if currentProfile.DbType == "mysql" {
@@ -486,7 +486,7 @@ func App(param string, step int, file string) {
 
 		if currentProfile.DbType == "psql" {
 			db_port, _ := strconv.Atoi(currentProfile.Port)
-			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database)
+			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode)
 			psql.GrantTablePermissions(stepper.Steps[step].Table, stepper.Steps[step].Username, stepper.Steps[step].Permission)
 			psql.Close()
 		} else if currentProfile.DbType == "mysql" {
@@ -515,7 +515,7 @@ func App(param string, step int, file string) {
 
 		if currentProfile.DbType == "psql" {
 			db_port, _ := strconv.Atoi(currentProfile.Port)
-			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database)
+			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode)
 			psql.ListDatabases()
 			psql.Close()
 		} else if currentProfile.DbType == "mysql" {
@@ -543,7 +543,7 @@ func App(param string, step int, file string) {
 
 		if currentProfile.DbType == "psql" {
 			db_port, _ := strconv.Atoi(currentProfile.Port)
-			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database)
+			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode)
 			psql.ListTables()
 			psql.Close()
 		} else if currentProfile.DbType == "mysql" {
@@ -571,7 +571,7 @@ func App(param string, step int, file string) {
 
 		if currentProfile.DbType == "psql" {
 			db_port, _ := strconv.Atoi(currentProfile.Port)
-			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database)
+			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode)
 			psql.ListUsers()
 			psql.Close()
 		} else if currentProfile.DbType == "mysql" {

--- a/cmd/helper/profile.go
+++ b/cmd/helper/profile.go
@@ -12,13 +12,14 @@ import (
 )
 
 type Profile struct {
-	DbType   string `json:"db-type" yaml:"db-type"`
-	Host     string `json:"host" yaml:"host"`
-	User     string `json:"user" yaml:"user"`
+	DbType  string `json:"db-type" yaml:"db-type"`
+	Host    string `json:"host" yaml:"host"`
+	User    string `json:"user" yaml:"user"`
 	Password string `json:"password" yaml:"password"`
 	Database string `json:"database" yaml:"database"`
-	Name     string `json:"name" yaml:"name"`
-	Port     string `json:"port" yaml:"port"`
+	Name    string `json:"name" yaml:"name"`
+	Port    string `json:"port" yaml:"port"`
+	SSLMode string `json:"ssl-mode" yaml:"ssl-mode"`
 }
 
 type Profiles struct {
@@ -215,7 +216,19 @@ func collectProfileData() Profile {
 	if profile.Port == "" {
 		profile.Port = defaultPort
 	}
-	profile.Name = readRequiredField("[7/7] Profile Name (how you will refer to this profile in CLI)")
+
+	if dbtype == "psql" {
+		fmt.Println("[7/8] PostgreSQL SSL Mode (disable, allow, prefer, require, verify-ca, verify-full) [Default: require]:")
+		fmt.Print("-> ")
+		sslmode, sslErr := reader.ReadString('\n')
+		if sslErr != nil {
+			log.Fatalf("Failed to read input: %v", sslErr)
+		}
+		profile.SSLMode = strings.TrimSpace(sslmode)
+		profile.Name = readRequiredField("[8/8] Profile Name (how you will refer to this profile in CLI)")
+	} else {
+		profile.Name = readRequiredField("[7/7] Profile Name (how you will refer to this profile in CLI)")
+	}
 
 	return profile
 }

--- a/cmd/psql/core.go
+++ b/cmd/psql/core.go
@@ -12,9 +12,12 @@ import (
 
 var DbConnection *sql.DB
 
-func NewConnection(host string, port int, user, password, dbname string) {
-	psqlInfo := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable connect_timeout=10",
-		host, port, user, password, dbname)
+func NewConnection(host string, port int, user, password, dbname, sslmode string) {
+	if sslmode == "" {
+		sslmode = "require"
+	}
+	psqlInfo := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s connect_timeout=10",
+		host, port, user, password, dbname, sslmode)
 	db, err := sql.Open("postgres", psqlInfo)
 
 	if err != nil {


### PR DESCRIPTION
Add ssl-mode field to Profile, wire it through psql.NewConnection (defaults to require when unset), and expose --ssl-mode on profile add. Interactive profile init prompts for SSL mode on psql profiles.