### PR TITLE
Prompt for password interactively when --pass is omitted

### DIFF
--- a/cmd/functions/profile/add.go
+++ b/cmd/functions/profile/add.go
@@ -6,13 +6,15 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"syscall"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 func AddProfileCommand(subcommand *cobra.Command) {
 	cmd := &cobra.Command{
-		Use:   "add [--file filepath | [name] --db-type [dbtype] --user [username] --pass [password] --host [hostname] --port [port] --database [database]]",
+		Use:   "add [--file filepath | [name] --db-type [dbtype] --user [username] [--pass password] --host [hostname] --port [port] --database [database]]",
 		Short: "Add a new database profile",
 		Long:  `Adds a new profile to the list of database connection profiles. You can add a profile by providing a YAML file or by specifying details manually.`,
 		Example: `
@@ -61,7 +63,7 @@ func runAddProfile(cmd *cobra.Command, args []string) {
 		name := args[0]
 
 		missingFlags := []string{}
-		requiredFlags := []string{"db-type", "user", "pass", "host", "port", "database"}
+		requiredFlags := []string{"db-type", "user", "host", "port", "database"}
 		for _, flag := range requiredFlags {
 			if !cmd.Flag(flag).Changed {
 				missingFlags = append(missingFlags, flag)
@@ -75,7 +77,25 @@ func runAddProfile(cmd *cobra.Command, args []string) {
 
 		dbtype, _ := cmd.Flags().GetString("db-type")
 		username, _ := cmd.Flags().GetString("user")
-		password, _ := cmd.Flags().GetString("pass")
+
+		var password string
+		if cmd.Flag("pass").Changed {
+			password, _ = cmd.Flags().GetString("pass")
+		} else {
+			fmt.Fprintf(os.Stderr, "Password: ")
+			raw, err := term.ReadPassword(int(syscall.Stdin))
+			fmt.Fprintln(os.Stderr)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to read password: %v\n", err)
+				os.Exit(1)
+			}
+			if len(raw) == 0 {
+				fmt.Fprintf(os.Stderr, "Password cannot be empty\n")
+				os.Exit(1)
+			}
+			password = string(raw)
+		}
+
 		host, _ := cmd.Flags().GetString("host")
 		port, _ := cmd.Flags().GetString("port")
 		database, _ := cmd.Flags().GetString("database")

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module dbac
 
-go 1.22.0
+go 1.25.0
 
 require (
 	github.com/denisbrodbeck/machineid v1.0.1
@@ -17,5 +17,6 @@ require (
 	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	golang.org/x/sys v0.27.0 // indirect
+	golang.org/x/sys v0.46.0 // indirect
+	golang.org/x/term v0.27.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,12 @@ github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPc
 github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
 golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
 golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.27.0 h1:WP60Sv1nlK1T6SupCHbXzSaN0b9wUmsPoRS9b61A23Q=
+golang.org/x/term v0.27.0/go.mod h1:iMsnZpn0cago0GOrHO2+Y7u7JPn5AylBrcoWkElMTSM=
+golang.org/x/term v0.44.0 h1:0rLvDRCtNj0gZkyIXhCyOb2OAzEhLVqc4B+hrsBhrmc=
+golang.org/x/term v0.44.0/go.mod h1:7ze4MdzUzLXpSAoFP1H0bOI9aXDqveSvatT5vKcFh2Y=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=


### PR DESCRIPTION
Remove --pass from required flags on profile add; fall back to term.ReadPassword() so credentials are never exposed in shell history or ps output. Flag still works for scripted use.