### PR TITLE
Require confirmation before delete-database and delete-user

### DIFF
--- a/cmd/functions/db/deletedatabase.go
+++ b/cmd/functions/db/deletedatabase.go
@@ -21,6 +21,7 @@ func AddDeleteDatabaseCommand(subcommand *cobra.Command) {
 		Run:     runDeleteDatabase,
 	}
 	cmd.Flags().String("database", "", "Database name to be deleted")
+	cmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
 	subcommand.AddCommand(cmd)
 }
 
@@ -36,6 +37,11 @@ func runDeleteDatabase(cmd *cobra.Command, args []string) {
 		if err := cmd.Help(); err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to display help: %v\n", err)
 		}
+		os.Exit(1)
+	}
+	yes, _ := cmd.Flags().GetBool("yes")
+	if !yes && !helper.Confirm(fmt.Sprintf("Delete database %q?", database)) {
+		fmt.Fprintln(os.Stderr, "Aborted.")
 		os.Exit(1)
 	}
 	profile := helper.ReadProfile(currentProfileName)

--- a/cmd/functions/db/deleteuser.go
+++ b/cmd/functions/db/deleteuser.go
@@ -21,6 +21,7 @@ func AddDeleteUserCommand(subcommand *cobra.Command) {
 		Run:     runDeleteUser,
 	}
 	cmd.Flags().String("username", "", "Username of the user to be deleted")
+	cmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
 	subcommand.AddCommand(cmd)
 }
 
@@ -36,6 +37,11 @@ func runDeleteUser(cmd *cobra.Command, args []string) {
 		if err := cmd.Help(); err != nil {
 			fmt.Fprintf(os.Stderr, "Failed to display help: %v\n", err)
 		}
+		os.Exit(1)
+	}
+	yes, _ := cmd.Flags().GetBool("yes")
+	if !yes && !helper.Confirm(fmt.Sprintf("Delete user %q?", username)) {
+		fmt.Fprintln(os.Stderr, "Aborted.")
 		os.Exit(1)
 	}
 	profile := helper.ReadProfile(currentProfileName)

--- a/cmd/helper/confirm.go
+++ b/cmd/helper/confirm.go
@@ -1,0 +1,19 @@
+package helper
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Confirm prints prompt to stderr and returns true only if the user types "y" or "yes".
+func Confirm(prompt string) bool {
+	fmt.Fprint(os.Stderr, prompt+" [y/N]: ")
+	scanner := bufio.NewScanner(os.Stdin)
+	if !scanner.Scan() {
+		return false
+	}
+	answer := strings.TrimSpace(strings.ToLower(scanner.Text()))
+	return answer == "y" || answer == "yes"
+}


### PR DESCRIPTION
Both commands now prompt interactively before dropping resources. Pass --yes / -y to skip the prompt in scripts and automation.