### PR TITLE
Refactor driver packages to return errors instead of log.Fatalf

### DIFF
--- a/cmd/functions/db/changepassword.go
+++ b/cmd/functions/db/changepassword.go
@@ -20,7 +20,6 @@ func AddChangePasswordCommand(subcommand *cobra.Command) {
 		Args:    cobra.NoArgs,
 		Run:     runChangePassword,
 	}
-
 	cmd.Flags().String("username", "", "Username of the user whose password is to be changed")
 	cmd.Flags().String("new-password", "", "New password for the user")
 	subcommand.AddCommand(cmd)
@@ -45,12 +44,30 @@ func runChangePassword(cmd *cobra.Command, args []string) {
 	switch profile.DbType {
 	case "psql":
 		dbPort, _ := strconv.Atoi(profile.Port)
-		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode)
-		psql.ChangeUserPassword(username, newPassword)
-		psql.Close()
+		if err := psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode); err != nil {
+			fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+			os.Exit(1)
+		}
+		if err := psql.ChangeUserPassword(username, newPassword); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := psql.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error closing connection: %v\n", err)
+			os.Exit(1)
+		}
 	case "mysql":
-		mysql.NewConnection(profile.Host, profile.Port, profile.User, profile.Password, profile.Database)
-		mysql.ChangeUserPassword(username, newPassword)
-		mysql.Close()
+		if err := mysql.NewConnection(profile.Host, profile.Port, profile.User, profile.Password, profile.Database); err != nil {
+			fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+			os.Exit(1)
+		}
+		if err := mysql.ChangeUserPassword(username, newPassword); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := mysql.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error closing connection: %v\n", err)
+			os.Exit(1)
+		}
 	}
 }

--- a/cmd/functions/db/createdatabase.go
+++ b/cmd/functions/db/createdatabase.go
@@ -42,12 +42,30 @@ func runCreateDatabase(cmd *cobra.Command, args []string) {
 	switch profile.DbType {
 	case "psql":
 		dbPort, _ := strconv.Atoi(profile.Port)
-		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode)
-		psql.CreateDatabase(database)
-		psql.Close()
+		if err := psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode); err != nil {
+			fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+			os.Exit(1)
+		}
+		if err := psql.CreateDatabase(database); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := psql.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error closing connection: %v\n", err)
+			os.Exit(1)
+		}
 	case "mysql":
-		mysql.NewConnection(profile.Host, profile.Port, profile.User, profile.Password, profile.Database)
-		mysql.CreateDatabase(database)
-		mysql.Close()
+		if err := mysql.NewConnection(profile.Host, profile.Port, profile.User, profile.Password, profile.Database); err != nil {
+			fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+			os.Exit(1)
+		}
+		if err := mysql.CreateDatabase(database); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := mysql.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error closing connection: %v\n", err)
+			os.Exit(1)
+		}
 	}
 }

--- a/cmd/functions/db/createuser.go
+++ b/cmd/functions/db/createuser.go
@@ -44,12 +44,30 @@ func runCreateUser(cmd *cobra.Command, args []string) {
 	switch profile.DbType {
 	case "psql":
 		dbPort, _ := strconv.Atoi(profile.Port)
-		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode)
-		psql.CreateUser(username, password)
-		psql.Close()
+		if err := psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode); err != nil {
+			fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+			os.Exit(1)
+		}
+		if err := psql.CreateUser(username, password); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := psql.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error closing connection: %v\n", err)
+			os.Exit(1)
+		}
 	case "mysql":
-		mysql.NewConnection(profile.Host, profile.Port, profile.User, profile.Password, profile.Database)
-		mysql.CreateUser(username, password)
-		mysql.Close()
+		if err := mysql.NewConnection(profile.Host, profile.Port, profile.User, profile.Password, profile.Database); err != nil {
+			fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+			os.Exit(1)
+		}
+		if err := mysql.CreateUser(username, password); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := mysql.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error closing connection: %v\n", err)
+			os.Exit(1)
+		}
 	}
 }

--- a/cmd/functions/db/deletedatabase.go
+++ b/cmd/functions/db/deletedatabase.go
@@ -48,12 +48,30 @@ func runDeleteDatabase(cmd *cobra.Command, args []string) {
 	switch profile.DbType {
 	case "psql":
 		dbPort, _ := strconv.Atoi(profile.Port)
-		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode)
-		psql.DeleteDatabase(database)
-		psql.Close()
+		if err := psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode); err != nil {
+			fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+			os.Exit(1)
+		}
+		if err := psql.DeleteDatabase(database); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := psql.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error closing connection: %v\n", err)
+			os.Exit(1)
+		}
 	case "mysql":
-		mysql.NewConnection(profile.Host, profile.Port, profile.User, profile.Password, profile.Database)
-		mysql.DeleteDatabase(database)
-		mysql.Close()
+		if err := mysql.NewConnection(profile.Host, profile.Port, profile.User, profile.Password, profile.Database); err != nil {
+			fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+			os.Exit(1)
+		}
+		if err := mysql.DeleteDatabase(database); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := mysql.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error closing connection: %v\n", err)
+			os.Exit(1)
+		}
 	}
 }

--- a/cmd/functions/db/deleteuser.go
+++ b/cmd/functions/db/deleteuser.go
@@ -48,12 +48,30 @@ func runDeleteUser(cmd *cobra.Command, args []string) {
 	switch profile.DbType {
 	case "psql":
 		dbPort, _ := strconv.Atoi(profile.Port)
-		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode)
-		psql.DeleteUser(username)
-		psql.Close()
+		if err := psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode); err != nil {
+			fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+			os.Exit(1)
+		}
+		if err := psql.DeleteUser(username); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := psql.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error closing connection: %v\n", err)
+			os.Exit(1)
+		}
 	case "mysql":
-		mysql.NewConnection(profile.Host, profile.Port, profile.User, profile.Password, profile.Database)
-		mysql.DeleteUser(username)
-		mysql.Close()
+		if err := mysql.NewConnection(profile.Host, profile.Port, profile.User, profile.Password, profile.Database); err != nil {
+			fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+			os.Exit(1)
+		}
+		if err := mysql.DeleteUser(username); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := mysql.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error closing connection: %v\n", err)
+			os.Exit(1)
+		}
 	}
 }

--- a/cmd/functions/db/exec.go
+++ b/cmd/functions/db/exec.go
@@ -51,25 +51,61 @@ func runExecCommand(cmd *cobra.Command, args []string) {
 		switch profile.DbType {
 		case "psql":
 			dbPort, _ := strconv.Atoi(profile.Port)
-			psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode)
-			psql.FileExec(file)
-			psql.Close()
+			if err := psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode); err != nil {
+				fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+				os.Exit(1)
+			}
+			if err := psql.FileExec(file); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				os.Exit(1)
+			}
+			if err := psql.Close(); err != nil {
+				fmt.Fprintf(os.Stderr, "Error closing connection: %v\n", err)
+				os.Exit(1)
+			}
 		case "mysql":
-			mysql.NewConnection(profile.Host, profile.Port, profile.User, profile.Password, profile.Database)
-			mysql.FileExec(file)
-			mysql.Close()
+			if err := mysql.NewConnection(profile.Host, profile.Port, profile.User, profile.Password, profile.Database); err != nil {
+				fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+				os.Exit(1)
+			}
+			if err := mysql.FileExec(file); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				os.Exit(1)
+			}
+			if err := mysql.Close(); err != nil {
+				fmt.Fprintf(os.Stderr, "Error closing connection: %v\n", err)
+				os.Exit(1)
+			}
 		}
 	} else {
 		switch profile.DbType {
 		case "psql":
 			dbPort, _ := strconv.Atoi(profile.Port)
-			psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode)
-			psql.Exec(query)
-			psql.Close()
+			if err := psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode); err != nil {
+				fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+				os.Exit(1)
+			}
+			if err := psql.Exec(query); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				os.Exit(1)
+			}
+			if err := psql.Close(); err != nil {
+				fmt.Fprintf(os.Stderr, "Error closing connection: %v\n", err)
+				os.Exit(1)
+			}
 		case "mysql":
-			mysql.NewConnection(profile.Host, profile.Port, profile.User, profile.Password, profile.Database)
-			mysql.Exec(query)
-			mysql.Close()
+			if err := mysql.NewConnection(profile.Host, profile.Port, profile.User, profile.Password, profile.Database); err != nil {
+				fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+				os.Exit(1)
+			}
+			if err := mysql.Exec(query); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+				os.Exit(1)
+			}
+			if err := mysql.Close(); err != nil {
+				fmt.Fprintf(os.Stderr, "Error closing connection: %v\n", err)
+				os.Exit(1)
+			}
 		}
 	}
 }

--- a/cmd/functions/db/grantdatabase.go
+++ b/cmd/functions/db/grantdatabase.go
@@ -52,12 +52,30 @@ func runGrantDatabase(cmd *cobra.Command, args []string) {
 	switch profile.DbType {
 	case "psql":
 		dbPort, _ := strconv.Atoi(profile.Port)
-		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode)
-		psql.GrantPermissions(database, username, permission)
-		psql.Close()
+		if err := psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode); err != nil {
+			fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+			os.Exit(1)
+		}
+		if err := psql.GrantPermissions(database, username, permission); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := psql.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error closing connection: %v\n", err)
+			os.Exit(1)
+		}
 	case "mysql":
-		mysql.NewConnection(profile.Host, profile.Port, profile.User, profile.Password, profile.Database)
-		mysql.GrantPermissions(database, username, permission)
-		mysql.Close()
+		if err := mysql.NewConnection(profile.Host, profile.Port, profile.User, profile.Password, profile.Database); err != nil {
+			fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+			os.Exit(1)
+		}
+		if err := mysql.GrantPermissions(database, username, permission); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := mysql.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error closing connection: %v\n", err)
+			os.Exit(1)
+		}
 	}
 }

--- a/cmd/functions/db/granttable.go
+++ b/cmd/functions/db/granttable.go
@@ -52,12 +52,30 @@ func runGrantTable(cmd *cobra.Command, args []string) {
 	switch profile.DbType {
 	case "psql":
 		dbPort, _ := strconv.Atoi(profile.Port)
-		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode)
-		psql.GrantTablePermissions(table, username, permission)
-		psql.Close()
+		if err := psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode); err != nil {
+			fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+			os.Exit(1)
+		}
+		if err := psql.GrantTablePermissions(table, username, permission); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := psql.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error closing connection: %v\n", err)
+			os.Exit(1)
+		}
 	case "mysql":
-		mysql.NewConnection(profile.Host, profile.Port, profile.User, profile.Password, profile.Database)
-		mysql.GrantTablePermissions(profile.Database, table, username, permission)
-		mysql.Close()
+		if err := mysql.NewConnection(profile.Host, profile.Port, profile.User, profile.Password, profile.Database); err != nil {
+			fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+			os.Exit(1)
+		}
+		if err := mysql.GrantTablePermissions(profile.Database, table, username, permission); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := mysql.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error closing connection: %v\n", err)
+			os.Exit(1)
+		}
 	}
 }

--- a/cmd/functions/db/listdatabases.go
+++ b/cmd/functions/db/listdatabases.go
@@ -33,12 +33,30 @@ func runListDatabases(cmd *cobra.Command, args []string) {
 	switch profile.DbType {
 	case "psql":
 		dbPort, _ := strconv.Atoi(profile.Port)
-		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode)
-		psql.ListDatabases()
-		psql.Close()
+		if err := psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode); err != nil {
+			fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+			os.Exit(1)
+		}
+		if err := psql.ListDatabases(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := psql.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error closing connection: %v\n", err)
+			os.Exit(1)
+		}
 	case "mysql":
-		mysql.NewConnection(profile.Host, profile.Port, profile.User, profile.Password, profile.Database)
-		mysql.ListDatabases()
-		mysql.Close()
+		if err := mysql.NewConnection(profile.Host, profile.Port, profile.User, profile.Password, profile.Database); err != nil {
+			fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+			os.Exit(1)
+		}
+		if err := mysql.ListDatabases(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := mysql.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error closing connection: %v\n", err)
+			os.Exit(1)
+		}
 	}
 }

--- a/cmd/functions/db/listtables.go
+++ b/cmd/functions/db/listtables.go
@@ -33,12 +33,30 @@ func runListTables(cmd *cobra.Command, args []string) {
 	switch profile.DbType {
 	case "psql":
 		dbPort, _ := strconv.Atoi(profile.Port)
-		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode)
-		psql.ListTables()
-		psql.Close()
+		if err := psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode); err != nil {
+			fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+			os.Exit(1)
+		}
+		if err := psql.ListTables(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := psql.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error closing connection: %v\n", err)
+			os.Exit(1)
+		}
 	case "mysql":
-		mysql.NewConnection(profile.Host, profile.Port, profile.User, profile.Password, profile.Database)
-		mysql.ListTables()
-		mysql.Close()
+		if err := mysql.NewConnection(profile.Host, profile.Port, profile.User, profile.Password, profile.Database); err != nil {
+			fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+			os.Exit(1)
+		}
+		if err := mysql.ListTables(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := mysql.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error closing connection: %v\n", err)
+			os.Exit(1)
+		}
 	}
 }

--- a/cmd/functions/db/listusers.go
+++ b/cmd/functions/db/listusers.go
@@ -33,12 +33,30 @@ func runListUsers(cmd *cobra.Command, args []string) {
 	switch profile.DbType {
 	case "psql":
 		dbPort, _ := strconv.Atoi(profile.Port)
-		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode)
-		psql.ListUsers()
-		psql.Close()
+		if err := psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode); err != nil {
+			fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+			os.Exit(1)
+		}
+		if err := psql.ListUsers(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := psql.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error closing connection: %v\n", err)
+			os.Exit(1)
+		}
 	case "mysql":
-		mysql.NewConnection(profile.Host, profile.Port, profile.User, profile.Password, profile.Database)
-		mysql.ListUsers()
-		mysql.Close()
+		if err := mysql.NewConnection(profile.Host, profile.Port, profile.User, profile.Password, profile.Database); err != nil {
+			fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+			os.Exit(1)
+		}
+		if err := mysql.ListUsers(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := mysql.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error closing connection: %v\n", err)
+			os.Exit(1)
+		}
 	}
 }

--- a/cmd/functions/db/ping.go
+++ b/cmd/functions/db/ping.go
@@ -33,12 +33,30 @@ func runPingDatabase(cmd *cobra.Command, args []string) {
 	switch profile.DbType {
 	case "psql":
 		dbPort, _ := strconv.Atoi(profile.Port)
-		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode)
-		psql.Ping()
-		psql.Close()
+		if err := psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode); err != nil {
+			fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+			os.Exit(1)
+		}
+		if err := psql.Ping(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := psql.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error closing connection: %v\n", err)
+			os.Exit(1)
+		}
 	case "mysql":
-		mysql.NewConnection(profile.Host, profile.Port, profile.User, profile.Password, profile.Database)
-		mysql.Ping()
-		mysql.Close()
+		if err := mysql.NewConnection(profile.Host, profile.Port, profile.User, profile.Password, profile.Database); err != nil {
+			fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+			os.Exit(1)
+		}
+		if err := mysql.Ping(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := mysql.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error closing connection: %v\n", err)
+			os.Exit(1)
+		}
 	}
 }

--- a/cmd/functions/db/revokedatabase.go
+++ b/cmd/functions/db/revokedatabase.go
@@ -52,12 +52,30 @@ func runRevokeDatabase(cmd *cobra.Command, args []string) {
 	switch profile.DbType {
 	case "psql":
 		dbPort, _ := strconv.Atoi(profile.Port)
-		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode)
-		psql.RevokePermissions(database, username, permission)
-		psql.Close()
+		if err := psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode); err != nil {
+			fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+			os.Exit(1)
+		}
+		if err := psql.RevokePermissions(database, username, permission); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := psql.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error closing connection: %v\n", err)
+			os.Exit(1)
+		}
 	case "mysql":
-		mysql.NewConnection(profile.Host, profile.Port, profile.User, profile.Password, profile.Database)
-		mysql.RevokePermissions(database, username, permission)
-		mysql.Close()
+		if err := mysql.NewConnection(profile.Host, profile.Port, profile.User, profile.Password, profile.Database); err != nil {
+			fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+			os.Exit(1)
+		}
+		if err := mysql.RevokePermissions(database, username, permission); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := mysql.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error closing connection: %v\n", err)
+			os.Exit(1)
+		}
 	}
 }

--- a/cmd/functions/db/revoketable.go
+++ b/cmd/functions/db/revoketable.go
@@ -52,12 +52,30 @@ func runRevokeTable(cmd *cobra.Command, args []string) {
 	switch profile.DbType {
 	case "psql":
 		dbPort, _ := strconv.Atoi(profile.Port)
-		psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode)
-		psql.RevokeTablePermissions(table, username, permission)
-		psql.Close()
+		if err := psql.NewConnection(profile.Host, dbPort, profile.User, profile.Password, profile.Database, profile.SSLMode); err != nil {
+			fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+			os.Exit(1)
+		}
+		if err := psql.RevokeTablePermissions(table, username, permission); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := psql.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error closing connection: %v\n", err)
+			os.Exit(1)
+		}
 	case "mysql":
-		mysql.NewConnection(profile.Host, profile.Port, profile.User, profile.Password, profile.Database)
-		mysql.RevokeTablePermissions(profile.Database, table, username, permission)
-		mysql.Close()
+		if err := mysql.NewConnection(profile.Host, profile.Port, profile.User, profile.Password, profile.Database); err != nil {
+			fmt.Fprintf(os.Stderr, "Error connecting to database: %v\n", err)
+			os.Exit(1)
+		}
+		if err := mysql.RevokeTablePermissions(profile.Database, table, username, permission); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := mysql.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error closing connection: %v\n", err)
+			os.Exit(1)
+		}
 	}
 }

--- a/cmd/helper/batch.go
+++ b/cmd/helper/batch.go
@@ -4,7 +4,6 @@ import (
 	"dbac/cmd/mysql"
 	"dbac/cmd/psql"
 	"fmt"
-	"log"
 	"os"
 	"strconv"
 
@@ -171,17 +170,24 @@ type ExecCommandSteps struct {
 	Steps []ExecCommand `yaml:"steps"`
 }
 
+func exitOnErr(err error) {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
 func RunBatch(file string) {
 	var stepper Steps
 	yamlFile, err := os.ReadFile(file)
 	if err != nil {
-		log.Printf("yamlFile.Get err   #%v ", err)
+		fmt.Fprintf(os.Stderr, "Error reading batch file: %v\n", err)
+		os.Exit(1)
 	}
-	err = yaml.Unmarshal(yamlFile, &stepper)
-	if err != nil {
-		log.Fatalf("Unmarshal: %v", err)
+	if err := yaml.Unmarshal(yamlFile, &stepper); err != nil {
+		fmt.Fprintf(os.Stderr, "Error parsing batch file: %v\n", err)
+		os.Exit(1)
 	}
-
 	for i := 0; i < len(stepper.Steps); i++ {
 		App(stepper.Steps[i].Type, i, file)
 	}
@@ -194,30 +200,28 @@ func App(param string, step int, file string) {
 		var stepper CreateUserSteps
 		yamlFile, err := os.ReadFile(file)
 		if err != nil {
-			log.Printf("yamlFile.Get err   #%v ", err)
+			fmt.Fprintf(os.Stderr, "Error reading batch file: %v\n", err)
+			os.Exit(1)
 		}
-		err = yaml.Unmarshal(yamlFile, &stepper)
-		if err != nil {
-			log.Fatalf("Unmarshal: %v", err)
+		if err := yaml.Unmarshal(yamlFile, &stepper); err != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing batch file: %v\n", err)
+			os.Exit(1)
 		}
-
 		if stepper.Steps[step].Profile == "" {
 			currentProfileName, _ := GetCurrentProfileName()
 			currentProfile = ReadProfile(currentProfileName)
 		} else {
 			currentProfile = ReadProfile(stepper.Steps[step].Profile)
 		}
-
 		if currentProfile.DbType == "psql" {
 			db_port, _ := strconv.Atoi(currentProfile.Port)
-
-			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode)
-			psql.CreateUser(stepper.Steps[step].Username, stepper.Steps[step].Password)
-			psql.Close()
+			exitOnErr(psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode))
+			exitOnErr(psql.CreateUser(stepper.Steps[step].Username, stepper.Steps[step].Password))
+			exitOnErr(psql.Close())
 		} else if currentProfile.DbType == "mysql" {
-			mysql.NewConnection(currentProfile.Host, currentProfile.Port, currentProfile.User, currentProfile.Password, currentProfile.Database)
-			mysql.CreateUser(stepper.Steps[step].Username, stepper.Steps[step].Password)
-			mysql.Close()
+			exitOnErr(mysql.NewConnection(currentProfile.Host, currentProfile.Port, currentProfile.User, currentProfile.Password, currentProfile.Database))
+			exitOnErr(mysql.CreateUser(stepper.Steps[step].Username, stepper.Steps[step].Password))
+			exitOnErr(mysql.Close())
 		}
 
 	case "create-database":
@@ -225,11 +229,12 @@ func App(param string, step int, file string) {
 		var stepper CreateDatabaseSteps
 		yamlFile, err := os.ReadFile(file)
 		if err != nil {
-			log.Printf("yamlFile.Get err   #%v ", err)
+			fmt.Fprintf(os.Stderr, "Error reading batch file: %v\n", err)
+			os.Exit(1)
 		}
-		err = yaml.Unmarshal(yamlFile, &stepper)
-		if err != nil {
-			log.Fatalf("Unmarshal: %v", err)
+		if err := yaml.Unmarshal(yamlFile, &stepper); err != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing batch file: %v\n", err)
+			os.Exit(1)
 		}
 		if stepper.Steps[step].Profile == "" {
 			currentProfileName, _ := GetCurrentProfileName()
@@ -237,17 +242,15 @@ func App(param string, step int, file string) {
 		} else {
 			currentProfile = ReadProfile(stepper.Steps[step].Profile)
 		}
-
 		if currentProfile.DbType == "psql" {
 			db_port, _ := strconv.Atoi(currentProfile.Port)
-
-			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode)
-			psql.CreateDatabase(stepper.Steps[step].Database)
-			psql.Close()
+			exitOnErr(psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode))
+			exitOnErr(psql.CreateDatabase(stepper.Steps[step].Database))
+			exitOnErr(psql.Close())
 		} else if currentProfile.DbType == "mysql" {
-			mysql.NewConnection(currentProfile.Host, currentProfile.Port, currentProfile.User, currentProfile.Password, currentProfile.Database)
-			mysql.CreateDatabase(stepper.Steps[step].Database)
-			mysql.Close()
+			exitOnErr(mysql.NewConnection(currentProfile.Host, currentProfile.Port, currentProfile.User, currentProfile.Password, currentProfile.Database))
+			exitOnErr(mysql.CreateDatabase(stepper.Steps[step].Database))
+			exitOnErr(mysql.Close())
 		}
 
 	case "grant-database":
@@ -255,11 +258,12 @@ func App(param string, step int, file string) {
 		var stepper GrantDatabaseSteps
 		yamlFile, err := os.ReadFile(file)
 		if err != nil {
-			log.Printf("yamlFile.Get err   #%v ", err)
+			fmt.Fprintf(os.Stderr, "Error reading batch file: %v\n", err)
+			os.Exit(1)
 		}
-		err = yaml.Unmarshal(yamlFile, &stepper)
-		if err != nil {
-			log.Fatalf("Unmarshal: %v", err)
+		if err := yaml.Unmarshal(yamlFile, &stepper); err != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing batch file: %v\n", err)
+			os.Exit(1)
 		}
 		if stepper.Steps[step].Profile == "" {
 			currentProfileName, _ := GetCurrentProfileName()
@@ -267,16 +271,15 @@ func App(param string, step int, file string) {
 		} else {
 			currentProfile = ReadProfile(stepper.Steps[step].Profile)
 		}
-
 		if currentProfile.DbType == "psql" {
 			db_port, _ := strconv.Atoi(currentProfile.Port)
-			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode)
-			psql.GrantPermissions(stepper.Steps[step].Database, stepper.Steps[step].Username, stepper.Steps[step].Permission)
-			psql.Close()
+			exitOnErr(psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode))
+			exitOnErr(psql.GrantPermissions(stepper.Steps[step].Database, stepper.Steps[step].Username, stepper.Steps[step].Permission))
+			exitOnErr(psql.Close())
 		} else if currentProfile.DbType == "mysql" {
-			mysql.NewConnection(currentProfile.Host, currentProfile.Port, currentProfile.User, currentProfile.Password, currentProfile.Database)
-			mysql.GrantPermissions(stepper.Steps[step].Database, stepper.Steps[step].Username, stepper.Steps[step].Permission)
-			mysql.Close()
+			exitOnErr(mysql.NewConnection(currentProfile.Host, currentProfile.Port, currentProfile.User, currentProfile.Password, currentProfile.Database))
+			exitOnErr(mysql.GrantPermissions(stepper.Steps[step].Database, stepper.Steps[step].Username, stepper.Steps[step].Permission))
+			exitOnErr(mysql.Close())
 		}
 
 	case "change-password":
@@ -284,11 +287,12 @@ func App(param string, step int, file string) {
 		var stepper ChangePasswordSteps
 		yamlFile, err := os.ReadFile(file)
 		if err != nil {
-			log.Printf("yamlFile.Get err   #%v ", err)
+			fmt.Fprintf(os.Stderr, "Error reading batch file: %v\n", err)
+			os.Exit(1)
 		}
-		err = yaml.Unmarshal(yamlFile, &stepper)
-		if err != nil {
-			log.Fatalf("Unmarshal: %v", err)
+		if err := yaml.Unmarshal(yamlFile, &stepper); err != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing batch file: %v\n", err)
+			os.Exit(1)
 		}
 		if stepper.Steps[step].Profile == "" {
 			currentProfileName, _ := GetCurrentProfileName()
@@ -296,16 +300,15 @@ func App(param string, step int, file string) {
 		} else {
 			currentProfile = ReadProfile(stepper.Steps[step].Profile)
 		}
-
 		if currentProfile.DbType == "psql" {
 			db_port, _ := strconv.Atoi(currentProfile.Port)
-			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode)
-			psql.ChangeUserPassword(stepper.Steps[step].Username, stepper.Steps[step].NewPassword)
-			psql.Close()
+			exitOnErr(psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode))
+			exitOnErr(psql.ChangeUserPassword(stepper.Steps[step].Username, stepper.Steps[step].NewPassword))
+			exitOnErr(psql.Close())
 		} else if currentProfile.DbType == "mysql" {
-			mysql.NewConnection(currentProfile.Host, currentProfile.Port, currentProfile.User, currentProfile.Password, currentProfile.Database)
-			mysql.ChangeUserPassword(stepper.Steps[step].Username, stepper.Steps[step].NewPassword)
-			mysql.Close()
+			exitOnErr(mysql.NewConnection(currentProfile.Host, currentProfile.Port, currentProfile.User, currentProfile.Password, currentProfile.Database))
+			exitOnErr(mysql.ChangeUserPassword(stepper.Steps[step].Username, stepper.Steps[step].NewPassword))
+			exitOnErr(mysql.Close())
 		}
 
 	case "revoke-database":
@@ -313,11 +316,12 @@ func App(param string, step int, file string) {
 		var stepper RevokeDatabaseSteps
 		yamlFile, err := os.ReadFile(file)
 		if err != nil {
-			log.Printf("yamlFile.Get err   #%v ", err)
+			fmt.Fprintf(os.Stderr, "Error reading batch file: %v\n", err)
+			os.Exit(1)
 		}
-		err = yaml.Unmarshal(yamlFile, &stepper)
-		if err != nil {
-			log.Fatalf("Unmarshal: %v", err)
+		if err := yaml.Unmarshal(yamlFile, &stepper); err != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing batch file: %v\n", err)
+			os.Exit(1)
 		}
 		if stepper.Steps[step].Profile == "" {
 			currentProfileName, _ := GetCurrentProfileName()
@@ -325,16 +329,15 @@ func App(param string, step int, file string) {
 		} else {
 			currentProfile = ReadProfile(stepper.Steps[step].Profile)
 		}
-
 		if currentProfile.DbType == "psql" {
 			db_port, _ := strconv.Atoi(currentProfile.Port)
-			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode)
-			psql.RevokePermissions(stepper.Steps[step].Database, stepper.Steps[step].Username, stepper.Steps[step].Permission)
-			psql.Close()
+			exitOnErr(psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode))
+			exitOnErr(psql.RevokePermissions(stepper.Steps[step].Database, stepper.Steps[step].Username, stepper.Steps[step].Permission))
+			exitOnErr(psql.Close())
 		} else if currentProfile.DbType == "mysql" {
-			mysql.NewConnection(currentProfile.Host, currentProfile.Port, currentProfile.User, currentProfile.Password, currentProfile.Database)
-			mysql.RevokePermissions(stepper.Steps[step].Database, stepper.Steps[step].Username, stepper.Steps[step].Permission)
-			mysql.Close()
+			exitOnErr(mysql.NewConnection(currentProfile.Host, currentProfile.Port, currentProfile.User, currentProfile.Password, currentProfile.Database))
+			exitOnErr(mysql.RevokePermissions(stepper.Steps[step].Database, stepper.Steps[step].Username, stepper.Steps[step].Permission))
+			exitOnErr(mysql.Close())
 		}
 
 	case "delete-user":
@@ -342,11 +345,12 @@ func App(param string, step int, file string) {
 		var stepper DeleteUserSteps
 		yamlFile, err := os.ReadFile(file)
 		if err != nil {
-			log.Printf("yamlFile.Get err   #%v ", err)
+			fmt.Fprintf(os.Stderr, "Error reading batch file: %v\n", err)
+			os.Exit(1)
 		}
-		err = yaml.Unmarshal(yamlFile, &stepper)
-		if err != nil {
-			log.Fatalf("Unmarshal: %v", err)
+		if err := yaml.Unmarshal(yamlFile, &stepper); err != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing batch file: %v\n", err)
+			os.Exit(1)
 		}
 		if stepper.Steps[step].Profile == "" {
 			currentProfileName, _ := GetCurrentProfileName()
@@ -354,16 +358,15 @@ func App(param string, step int, file string) {
 		} else {
 			currentProfile = ReadProfile(stepper.Steps[step].Profile)
 		}
-
 		if currentProfile.DbType == "psql" {
 			db_port, _ := strconv.Atoi(currentProfile.Port)
-			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode)
-			psql.DeleteUser(stepper.Steps[step].Username)
-			psql.Close()
+			exitOnErr(psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode))
+			exitOnErr(psql.DeleteUser(stepper.Steps[step].Username))
+			exitOnErr(psql.Close())
 		} else if currentProfile.DbType == "mysql" {
-			mysql.NewConnection(currentProfile.Host, currentProfile.Port, currentProfile.User, currentProfile.Password, currentProfile.Database)
-			mysql.DeleteUser(stepper.Steps[step].Username)
-			mysql.Close()
+			exitOnErr(mysql.NewConnection(currentProfile.Host, currentProfile.Port, currentProfile.User, currentProfile.Password, currentProfile.Database))
+			exitOnErr(mysql.DeleteUser(stepper.Steps[step].Username))
+			exitOnErr(mysql.Close())
 		}
 
 	case "delete-database":
@@ -371,11 +374,12 @@ func App(param string, step int, file string) {
 		var stepper DeleteDatabaseSteps
 		yamlFile, err := os.ReadFile(file)
 		if err != nil {
-			log.Printf("yamlFile.Get err   #%v ", err)
+			fmt.Fprintf(os.Stderr, "Error reading batch file: %v\n", err)
+			os.Exit(1)
 		}
-		err = yaml.Unmarshal(yamlFile, &stepper)
-		if err != nil {
-			log.Fatalf("Unmarshal: %v", err)
+		if err := yaml.Unmarshal(yamlFile, &stepper); err != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing batch file: %v\n", err)
+			os.Exit(1)
 		}
 		if stepper.Steps[step].Profile == "" {
 			currentProfileName, _ := GetCurrentProfileName()
@@ -383,16 +387,15 @@ func App(param string, step int, file string) {
 		} else {
 			currentProfile = ReadProfile(stepper.Steps[step].Profile)
 		}
-
 		if currentProfile.DbType == "psql" {
 			db_port, _ := strconv.Atoi(currentProfile.Port)
-			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode)
-			psql.DeleteDatabase(stepper.Steps[step].Database)
-			psql.Close()
+			exitOnErr(psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode))
+			exitOnErr(psql.DeleteDatabase(stepper.Steps[step].Database))
+			exitOnErr(psql.Close())
 		} else if currentProfile.DbType == "mysql" {
-			mysql.NewConnection(currentProfile.Host, currentProfile.Port, currentProfile.User, currentProfile.Password, currentProfile.Database)
-			mysql.DeleteDatabase(stepper.Steps[step].Database)
-			mysql.Close()
+			exitOnErr(mysql.NewConnection(currentProfile.Host, currentProfile.Port, currentProfile.User, currentProfile.Password, currentProfile.Database))
+			exitOnErr(mysql.DeleteDatabase(stepper.Steps[step].Database))
+			exitOnErr(mysql.Close())
 		}
 
 	case "exec":
@@ -400,11 +403,12 @@ func App(param string, step int, file string) {
 		var stepper ExecCommandSteps
 		yamlFile, err := os.ReadFile(file)
 		if err != nil {
-			log.Printf("yamlFile.Get err   #%v ", err)
+			fmt.Fprintf(os.Stderr, "Error reading batch file: %v\n", err)
+			os.Exit(1)
 		}
-		err = yaml.Unmarshal(yamlFile, &stepper)
-		if err != nil {
-			log.Fatalf("Unmarshal: %v", err)
+		if err := yaml.Unmarshal(yamlFile, &stepper); err != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing batch file: %v\n", err)
+			os.Exit(1)
 		}
 		if stepper.Steps[step].Profile == "" {
 			currentProfileName, _ := GetCurrentProfileName()
@@ -415,25 +419,25 @@ func App(param string, step int, file string) {
 		if stepper.Steps[step].File == "" {
 			if currentProfile.DbType == "psql" {
 				db_port, _ := strconv.Atoi(currentProfile.Port)
-				psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode)
-				psql.Exec(stepper.Steps[step].Query)
-				psql.Close()
+				exitOnErr(psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode))
+				exitOnErr(psql.Exec(stepper.Steps[step].Query))
+				exitOnErr(psql.Close())
 			} else if currentProfile.DbType == "mysql" {
-				mysql.NewConnection(currentProfile.Host, currentProfile.Port, currentProfile.User, currentProfile.Password, currentProfile.Database)
-				mysql.Exec(stepper.Steps[step].Query)
-				mysql.Close()
+				exitOnErr(mysql.NewConnection(currentProfile.Host, currentProfile.Port, currentProfile.User, currentProfile.Password, currentProfile.Database))
+				exitOnErr(mysql.Exec(stepper.Steps[step].Query))
+				exitOnErr(mysql.Close())
 			}
 		} else {
 			if currentProfile.DbType == "psql" {
 				db_port, _ := strconv.Atoi(currentProfile.Port)
-				psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode)
-				psql.FileExec(stepper.Steps[step].File)
-				psql.Close()
+				exitOnErr(psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode))
+				exitOnErr(psql.FileExec(stepper.Steps[step].File))
+				exitOnErr(psql.Close())
 			} else if currentProfile.DbType == "mysql" {
 				fmt.Println(stepper.Steps[step].File)
-				mysql.NewConnection(currentProfile.Host, currentProfile.Port, currentProfile.User, currentProfile.Password, currentProfile.Database)
-				mysql.FileExec(stepper.Steps[step].File)
-				mysql.Close()
+				exitOnErr(mysql.NewConnection(currentProfile.Host, currentProfile.Port, currentProfile.User, currentProfile.Password, currentProfile.Database))
+				exitOnErr(mysql.FileExec(stepper.Steps[step].File))
+				exitOnErr(mysql.Close())
 			}
 		}
 
@@ -442,11 +446,12 @@ func App(param string, step int, file string) {
 		var stepper RevokeTableSteps
 		yamlFile, err := os.ReadFile(file)
 		if err != nil {
-			log.Printf("yamlFile.Get err   #%v ", err)
+			fmt.Fprintf(os.Stderr, "Error reading batch file: %v\n", err)
+			os.Exit(1)
 		}
-		err = yaml.Unmarshal(yamlFile, &stepper)
-		if err != nil {
-			log.Fatalf("Unmarshal: %v", err)
+		if err := yaml.Unmarshal(yamlFile, &stepper); err != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing batch file: %v\n", err)
+			os.Exit(1)
 		}
 		if stepper.Steps[step].Profile == "" {
 			currentProfileName, _ := GetCurrentProfileName()
@@ -454,16 +459,15 @@ func App(param string, step int, file string) {
 		} else {
 			currentProfile = ReadProfile(stepper.Steps[step].Profile)
 		}
-
 		if currentProfile.DbType == "psql" {
 			db_port, _ := strconv.Atoi(currentProfile.Port)
-			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode)
-			psql.RevokeTablePermissions(stepper.Steps[step].Table, stepper.Steps[step].Username, stepper.Steps[step].Permission)
-			psql.Close()
+			exitOnErr(psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode))
+			exitOnErr(psql.RevokeTablePermissions(stepper.Steps[step].Table, stepper.Steps[step].Username, stepper.Steps[step].Permission))
+			exitOnErr(psql.Close())
 		} else if currentProfile.DbType == "mysql" {
-			mysql.NewConnection(currentProfile.Host, currentProfile.Port, currentProfile.User, currentProfile.Password, currentProfile.Database)
-			mysql.RevokeTablePermissions(currentProfile.Database, stepper.Steps[step].Table, stepper.Steps[step].Username, stepper.Steps[step].Permission)
-			mysql.Close()
+			exitOnErr(mysql.NewConnection(currentProfile.Host, currentProfile.Port, currentProfile.User, currentProfile.Password, currentProfile.Database))
+			exitOnErr(mysql.RevokeTablePermissions(currentProfile.Database, stepper.Steps[step].Table, stepper.Steps[step].Username, stepper.Steps[step].Permission))
+			exitOnErr(mysql.Close())
 		}
 
 	case "grant-table":
@@ -471,11 +475,12 @@ func App(param string, step int, file string) {
 		var stepper GrantTableSteps
 		yamlFile, err := os.ReadFile(file)
 		if err != nil {
-			log.Printf("yamlFile.Get err   #%v ", err)
+			fmt.Fprintf(os.Stderr, "Error reading batch file: %v\n", err)
+			os.Exit(1)
 		}
-		err = yaml.Unmarshal(yamlFile, &stepper)
-		if err != nil {
-			log.Fatalf("Unmarshal: %v", err)
+		if err := yaml.Unmarshal(yamlFile, &stepper); err != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing batch file: %v\n", err)
+			os.Exit(1)
 		}
 		if stepper.Steps[step].Profile == "" {
 			currentProfileName, _ := GetCurrentProfileName()
@@ -483,16 +488,15 @@ func App(param string, step int, file string) {
 		} else {
 			currentProfile = ReadProfile(stepper.Steps[step].Profile)
 		}
-
 		if currentProfile.DbType == "psql" {
 			db_port, _ := strconv.Atoi(currentProfile.Port)
-			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode)
-			psql.GrantTablePermissions(stepper.Steps[step].Table, stepper.Steps[step].Username, stepper.Steps[step].Permission)
-			psql.Close()
+			exitOnErr(psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode))
+			exitOnErr(psql.GrantTablePermissions(stepper.Steps[step].Table, stepper.Steps[step].Username, stepper.Steps[step].Permission))
+			exitOnErr(psql.Close())
 		} else if currentProfile.DbType == "mysql" {
-			mysql.NewConnection(currentProfile.Host, currentProfile.Port, currentProfile.User, currentProfile.Password, currentProfile.Database)
-			mysql.GrantTablePermissions(currentProfile.Database, stepper.Steps[step].Table, stepper.Steps[step].Username, stepper.Steps[step].Permission)
-			mysql.Close()
+			exitOnErr(mysql.NewConnection(currentProfile.Host, currentProfile.Port, currentProfile.User, currentProfile.Password, currentProfile.Database))
+			exitOnErr(mysql.GrantTablePermissions(currentProfile.Database, stepper.Steps[step].Table, stepper.Steps[step].Username, stepper.Steps[step].Permission))
+			exitOnErr(mysql.Close())
 		}
 
 	case "list-databases":
@@ -500,11 +504,12 @@ func App(param string, step int, file string) {
 		var stepper ListDatabasesSteps
 		yamlFile, err := os.ReadFile(file)
 		if err != nil {
-			log.Printf("yamlFile.Get err   #%v ", err)
+			fmt.Fprintf(os.Stderr, "Error reading batch file: %v\n", err)
+			os.Exit(1)
 		}
-		err = yaml.Unmarshal(yamlFile, &stepper)
-		if err != nil {
-			log.Fatalf("Unmarshal: %v", err)
+		if err := yaml.Unmarshal(yamlFile, &stepper); err != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing batch file: %v\n", err)
+			os.Exit(1)
 		}
 		if stepper.Steps[step].Profile == "" {
 			currentProfileName, _ := GetCurrentProfileName()
@@ -512,27 +517,28 @@ func App(param string, step int, file string) {
 		} else {
 			currentProfile = ReadProfile(stepper.Steps[step].Profile)
 		}
-
 		if currentProfile.DbType == "psql" {
 			db_port, _ := strconv.Atoi(currentProfile.Port)
-			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode)
-			psql.ListDatabases()
-			psql.Close()
+			exitOnErr(psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode))
+			exitOnErr(psql.ListDatabases())
+			exitOnErr(psql.Close())
 		} else if currentProfile.DbType == "mysql" {
-			mysql.NewConnection(currentProfile.Host, currentProfile.Port, currentProfile.User, currentProfile.Password, currentProfile.Database)
-			mysql.ListDatabases()
-			mysql.Close()
+			exitOnErr(mysql.NewConnection(currentProfile.Host, currentProfile.Port, currentProfile.User, currentProfile.Password, currentProfile.Database))
+			exitOnErr(mysql.ListDatabases())
+			exitOnErr(mysql.Close())
 		}
+
 	case "list-tables":
 		var currentProfile Profile
 		var stepper ListTablesSteps
 		yamlFile, err := os.ReadFile(file)
 		if err != nil {
-			log.Printf("yamlFile.Get err   #%v ", err)
+			fmt.Fprintf(os.Stderr, "Error reading batch file: %v\n", err)
+			os.Exit(1)
 		}
-		err = yaml.Unmarshal(yamlFile, &stepper)
-		if err != nil {
-			log.Fatalf("Unmarshal: %v", err)
+		if err := yaml.Unmarshal(yamlFile, &stepper); err != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing batch file: %v\n", err)
+			os.Exit(1)
 		}
 		if stepper.Steps[step].Profile == "" {
 			currentProfileName, _ := GetCurrentProfileName()
@@ -540,27 +546,28 @@ func App(param string, step int, file string) {
 		} else {
 			currentProfile = ReadProfile(stepper.Steps[step].Profile)
 		}
-
 		if currentProfile.DbType == "psql" {
 			db_port, _ := strconv.Atoi(currentProfile.Port)
-			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode)
-			psql.ListTables()
-			psql.Close()
+			exitOnErr(psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode))
+			exitOnErr(psql.ListTables())
+			exitOnErr(psql.Close())
 		} else if currentProfile.DbType == "mysql" {
-			mysql.NewConnection(currentProfile.Host, currentProfile.Port, currentProfile.User, currentProfile.Password, currentProfile.Database)
-			mysql.ListTables()
-			mysql.Close()
+			exitOnErr(mysql.NewConnection(currentProfile.Host, currentProfile.Port, currentProfile.User, currentProfile.Password, currentProfile.Database))
+			exitOnErr(mysql.ListTables())
+			exitOnErr(mysql.Close())
 		}
+
 	case "list-users":
 		var currentProfile Profile
 		var stepper ListUsersSteps
 		yamlFile, err := os.ReadFile(file)
 		if err != nil {
-			log.Printf("yamlFile.Get err   #%v ", err)
+			fmt.Fprintf(os.Stderr, "Error reading batch file: %v\n", err)
+			os.Exit(1)
 		}
-		err = yaml.Unmarshal(yamlFile, &stepper)
-		if err != nil {
-			log.Fatalf("Unmarshal: %v", err)
+		if err := yaml.Unmarshal(yamlFile, &stepper); err != nil {
+			fmt.Fprintf(os.Stderr, "Error parsing batch file: %v\n", err)
+			os.Exit(1)
 		}
 		if stepper.Steps[step].Profile == "" {
 			currentProfileName, _ := GetCurrentProfileName()
@@ -568,16 +575,15 @@ func App(param string, step int, file string) {
 		} else {
 			currentProfile = ReadProfile(stepper.Steps[step].Profile)
 		}
-
 		if currentProfile.DbType == "psql" {
 			db_port, _ := strconv.Atoi(currentProfile.Port)
-			psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode)
-			psql.ListUsers()
-			psql.Close()
+			exitOnErr(psql.NewConnection(currentProfile.Host, db_port, currentProfile.User, currentProfile.Password, currentProfile.Database, currentProfile.SSLMode))
+			exitOnErr(psql.ListUsers())
+			exitOnErr(psql.Close())
 		} else if currentProfile.DbType == "mysql" {
-			mysql.NewConnection(currentProfile.Host, currentProfile.Port, currentProfile.User, currentProfile.Password, currentProfile.Database)
-			mysql.ListUsers()
-			mysql.Close()
+			exitOnErr(mysql.NewConnection(currentProfile.Host, currentProfile.Port, currentProfile.User, currentProfile.Password, currentProfile.Database))
+			exitOnErr(mysql.ListUsers())
+			exitOnErr(mysql.Close())
 		}
 	}
 }

--- a/cmd/mysql/core.go
+++ b/cmd/mysql/core.go
@@ -3,7 +3,6 @@ package mysql
 import (
 	"database/sql"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 	"time"
@@ -13,9 +12,8 @@ import (
 
 var DbConnection *sql.DB
 
-func NewConnection(host, port, user, password, dbname string) {
+func NewConnection(host, port, user, password, dbname string) error {
 	addr := fmt.Sprintf("%s:%s", host, port)
-
 	cfg := mysql.Config{
 		User:    user,
 		Passwd:  password,
@@ -24,38 +22,39 @@ func NewConnection(host, port, user, password, dbname string) {
 		DBName:  dbname,
 		Timeout: 10 * time.Second,
 	}
-
 	db, err := sql.Open("mysql", cfg.FormatDSN())
 	if err != nil {
-		log.Fatalf("Failed to open database connection: %v", err)
+		return fmt.Errorf("failed to open database connection: %w", err)
 	}
-
 	DbConnection = db
+	return nil
 }
 
-func Ping() {
+func Ping() error {
 	if err := DbConnection.Ping(); err != nil {
-		log.Fatalf("Failed to ping database: %v", err)
+		return fmt.Errorf("failed to ping database: %w", err)
 	}
 	fmt.Println("Connection Success")
+	return nil
 }
 
-func Close() {
+func Close() error {
 	if err := DbConnection.Close(); err != nil {
-		log.Fatalf("Failed to close database connection: %v", err)
+		return fmt.Errorf("failed to close database connection: %w", err)
 	}
+	return nil
 }
 
-func Exec(query string) {
+func Exec(query string) error {
 	rows, err := DbConnection.Query(query)
 	if err != nil {
-		log.Fatalf("Failed to execute query: %v", err)
+		return fmt.Errorf("failed to execute query: %w", err)
 	}
 	defer rows.Close()
 
 	columns, err := rows.Columns()
 	if err != nil {
-		log.Fatalf("Failed to get columns: %v", err)
+		return fmt.Errorf("failed to get columns: %w", err)
 	}
 
 	values := make([]sql.RawBytes, len(columns))
@@ -66,40 +65,37 @@ func Exec(query string) {
 
 	for rows.Next() {
 		if err := rows.Scan(scanArgs...); err != nil {
-			log.Fatalf("Failed to scan row: %v", err)
+			return fmt.Errorf("failed to scan row: %w", err)
 		}
-
 		for i, col := range values {
 			fmt.Printf("%s: %s\n", columns[i], col)
 		}
 		fmt.Println("---------------------")
 	}
-
 	if err := rows.Err(); err != nil {
-		log.Fatalf("Failed to iterate over rows: %v", err)
+		return fmt.Errorf("failed to iterate over rows: %w", err)
 	}
-
 	fmt.Println("Query run successfully")
+	return nil
 }
 
-func FileExec(filename string) {
+func FileExec(filename string) error {
 	file, err := os.ReadFile(filename)
 	if err != nil {
-		log.Fatalf("Failed to read SQL file: %v", err)
+		return fmt.Errorf("failed to read SQL file: %w", err)
 	}
-
 	commands := strings.Split(string(file), ";")
 	for _, cmd := range commands {
 		cmd = strings.TrimSpace(cmd)
 		if cmd == "" {
 			continue
 		}
-
 		if _, err := DbConnection.Exec(cmd); err != nil {
-			log.Fatalf("Failed to execute command: %v", err)
+			return fmt.Errorf("failed to execute command: %w", err)
 		}
 	}
 	fmt.Println("SQL file run successfully")
+	return nil
 }
 
 func quoteIdentifier(name string) string {
@@ -112,11 +108,11 @@ func quoteLiteral(s string) string {
 	return "'" + s + "'"
 }
 
-func validatePermissions(permissions string) string {
+func validatePermissions(permissions string) (string, error) {
 	for _, r := range permissions {
 		if !((r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || r == ' ' || r == ',' || r == '_') {
-			log.Fatalf("invalid permissions: %q", permissions)
+			return "", fmt.Errorf("invalid permissions: %q", permissions)
 		}
 	}
-	return permissions
+	return permissions, nil
 }

--- a/cmd/mysql/database.go
+++ b/cmd/mysql/database.go
@@ -1,15 +1,11 @@
 package mysql
 
-import (
-	"fmt"
-	"log"
-)
+import "fmt"
 
-func ListDatabases() {
-	query := "SHOW DATABASES;"
-	rows, err := DbConnection.Query(query)
+func ListDatabases() error {
+	rows, err := DbConnection.Query("SHOW DATABASES;")
 	if err != nil {
-		log.Fatalf("Failed to execute query: %v", err)
+		return fmt.Errorf("failed to execute query: %w", err)
 	}
 	defer rows.Close()
 
@@ -17,25 +13,23 @@ func ListDatabases() {
 	for rows.Next() {
 		var database string
 		if err := rows.Scan(&database); err != nil {
-			log.Fatalf("Failed to scan row: %v", err)
+			return fmt.Errorf("failed to scan row: %w", err)
 		}
 		databases = append(databases, database)
 	}
-
 	if err := rows.Err(); err != nil {
-		log.Fatalf("Row iteration error: %v", err)
+		return fmt.Errorf("failed to iterate over rows: %w", err)
 	}
-
 	for _, db := range databases {
 		fmt.Println(db)
 	}
+	return nil
 }
 
-func ListTables() {
-	query := "SHOW TABLES;"
-	rows, err := DbConnection.Query(query)
+func ListTables() error {
+	rows, err := DbConnection.Query("SHOW TABLES;")
 	if err != nil {
-		log.Fatalf("Failed to execute query: %v", err)
+		return fmt.Errorf("failed to execute query: %w", err)
 	}
 	defer rows.Close()
 
@@ -43,34 +37,31 @@ func ListTables() {
 	for rows.Next() {
 		var table string
 		if err := rows.Scan(&table); err != nil {
-			log.Fatalf("Failed to scan row: %v", err)
+			return fmt.Errorf("failed to scan row: %w", err)
 		}
 		tables = append(tables, table)
 	}
-
 	if err := rows.Err(); err != nil {
-		log.Fatalf("Row iteration error: %v", err)
+		return fmt.Errorf("failed to iterate over rows: %w", err)
 	}
-
 	for _, table := range tables {
 		fmt.Println(table)
 	}
+	return nil
 }
 
-func CreateDatabase(database string) {
-	_, err := DbConnection.Exec("CREATE DATABASE " + quoteIdentifier(database) + ";")
-	if err != nil {
-		log.Printf("Database couldn't be created: %v", err)
-		return
+func CreateDatabase(database string) error {
+	if _, err := DbConnection.Exec("CREATE DATABASE " + quoteIdentifier(database) + ";"); err != nil {
+		return fmt.Errorf("failed to create database: %w", err)
 	}
 	fmt.Println("Database created successfully")
+	return nil
 }
 
-func DeleteDatabase(database string) {
-	_, err := DbConnection.Exec("DROP DATABASE " + quoteIdentifier(database) + ";")
-	if err != nil {
-		log.Printf("Database couldn't be deleted: %v", err)
-		return
+func DeleteDatabase(database string) error {
+	if _, err := DbConnection.Exec("DROP DATABASE " + quoteIdentifier(database) + ";"); err != nil {
+		return fmt.Errorf("failed to delete database: %w", err)
 	}
 	fmt.Println("Database deleted successfully")
+	return nil
 }

--- a/cmd/mysql/permission.go
+++ b/cmd/mysql/permission.go
@@ -1,42 +1,55 @@
 package mysql
 
-import (
-	"fmt"
-	"log"
-)
+import "fmt"
 
-func GrantPermissions(database, username, permissions string) {
-	query := "GRANT " + validatePermissions(permissions) + " ON " + quoteIdentifier(database) + ".* TO " + quoteLiteral(username) + "@'%';"
+func GrantPermissions(database, username, permissions string) error {
+	perm, err := validatePermissions(permissions)
+	if err != nil {
+		return err
+	}
+	query := "GRANT " + perm + " ON " + quoteIdentifier(database) + ".* TO " + quoteLiteral(username) + "@'%';"
 	if _, err := DbConnection.Exec(query); err != nil {
-		log.Printf("Permission couldn't be added: %v", err)
-		return
+		return fmt.Errorf("failed to grant permissions: %w", err)
 	}
 	fmt.Println("Permission added successfully")
+	return nil
 }
 
-func RevokePermissions(database, username, permissions string) {
-	query := "REVOKE " + validatePermissions(permissions) + " ON " + quoteIdentifier(database) + ".* FROM " + quoteLiteral(username) + "@'%';"
+func RevokePermissions(database, username, permissions string) error {
+	perm, err := validatePermissions(permissions)
+	if err != nil {
+		return err
+	}
+	query := "REVOKE " + perm + " ON " + quoteIdentifier(database) + ".* FROM " + quoteLiteral(username) + "@'%';"
 	if _, err := DbConnection.Exec(query); err != nil {
-		log.Printf("Permission couldn't be revoked: %v", err)
-		return
+		return fmt.Errorf("failed to revoke permissions: %w", err)
 	}
 	fmt.Println("Permission revoked successfully")
+	return nil
 }
 
-func GrantTablePermissions(database, table, username, permissions string) {
-	query := "GRANT " + validatePermissions(permissions) + " ON " + quoteIdentifier(database) + "." + quoteIdentifier(table) + " TO " + quoteLiteral(username) + "@'%';"
+func GrantTablePermissions(database, table, username, permissions string) error {
+	perm, err := validatePermissions(permissions)
+	if err != nil {
+		return err
+	}
+	query := "GRANT " + perm + " ON " + quoteIdentifier(database) + "." + quoteIdentifier(table) + " TO " + quoteLiteral(username) + "@'%';"
 	if _, err := DbConnection.Exec(query); err != nil {
-		log.Printf("Permission couldn't be added: %v", err)
-		return
+		return fmt.Errorf("failed to grant table permissions: %w", err)
 	}
 	fmt.Println("Permission added successfully")
+	return nil
 }
 
-func RevokeTablePermissions(database, table, username, permissions string) {
-	query := "REVOKE " + validatePermissions(permissions) + " ON " + quoteIdentifier(database) + "." + quoteIdentifier(table) + " FROM " + quoteLiteral(username) + "@'%';"
+func RevokeTablePermissions(database, table, username, permissions string) error {
+	perm, err := validatePermissions(permissions)
+	if err != nil {
+		return err
+	}
+	query := "REVOKE " + perm + " ON " + quoteIdentifier(database) + "." + quoteIdentifier(table) + " FROM " + quoteLiteral(username) + "@'%';"
 	if _, err := DbConnection.Exec(query); err != nil {
-		log.Printf("Permission couldn't be revoked: %v", err)
-		return
+		return fmt.Errorf("failed to revoke table permissions: %w", err)
 	}
 	fmt.Println("Permission revoked successfully")
+	return nil
 }

--- a/cmd/mysql/user.go
+++ b/cmd/mysql/user.go
@@ -1,15 +1,11 @@
 package mysql
 
-import (
-	"fmt"
-	"log"
-)
+import "fmt"
 
-func ListUsers() {
-	query := "SELECT user FROM mysql.user;"
-	rows, err := DbConnection.Query(query)
+func ListUsers() error {
+	rows, err := DbConnection.Query("SELECT user FROM mysql.user;")
 	if err != nil {
-		log.Fatalf("Failed to execute query: %v", err)
+		return fmt.Errorf("failed to execute query: %w", err)
 	}
 	defer rows.Close()
 
@@ -17,43 +13,42 @@ func ListUsers() {
 	for rows.Next() {
 		var user string
 		if err := rows.Scan(&user); err != nil {
-			log.Fatalf("Failed to scan row: %v", err)
+			return fmt.Errorf("failed to scan row: %w", err)
 		}
 		users = append(users, user)
 	}
-
 	if err := rows.Err(); err != nil {
-		log.Fatalf("Failed to iterate over rows: %v", err)
+		return fmt.Errorf("failed to iterate over rows: %w", err)
 	}
-
 	for _, user := range users {
 		fmt.Println(user)
 	}
+	return nil
 }
 
-func CreateUser(username, password string) {
+func CreateUser(username, password string) error {
 	query := "CREATE USER " + quoteLiteral(username) + "@'%' IDENTIFIED BY " + quoteLiteral(password) + ";"
 	if _, err := DbConnection.Exec(query); err != nil {
-		log.Printf("User couldn't be created: %v", err)
-		return
+		return fmt.Errorf("failed to create user: %w", err)
 	}
 	fmt.Println("User created successfully")
+	return nil
 }
 
-func DeleteUser(username string) {
+func DeleteUser(username string) error {
 	query := "DROP USER " + quoteLiteral(username) + "@'%';"
 	if _, err := DbConnection.Exec(query); err != nil {
-		log.Printf("User couldn't be deleted: %v", err)
-		return
+		return fmt.Errorf("failed to delete user: %w", err)
 	}
 	fmt.Println("User deleted successfully")
+	return nil
 }
 
-func ChangeUserPassword(username, newPassword string) {
+func ChangeUserPassword(username, newPassword string) error {
 	query := "ALTER USER " + quoteLiteral(username) + "@'%' IDENTIFIED BY " + quoteLiteral(newPassword) + ";"
 	if _, err := DbConnection.Exec(query); err != nil {
-		log.Printf("Password couldn't be changed: %v", err)
-		return
+		return fmt.Errorf("failed to change user password: %w", err)
 	}
 	fmt.Println("Password changed successfully")
+	return nil
 }

--- a/cmd/psql/core.go
+++ b/cmd/psql/core.go
@@ -3,7 +3,6 @@ package psql
 import (
 	"database/sql"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 
@@ -12,63 +11,63 @@ import (
 
 var DbConnection *sql.DB
 
-func NewConnection(host string, port int, user, password, dbname, sslmode string) {
+func NewConnection(host string, port int, user, password, dbname, sslmode string) error {
 	if sslmode == "" {
 		sslmode = "require"
 	}
 	psqlInfo := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s connect_timeout=10",
 		host, port, user, password, dbname, sslmode)
 	db, err := sql.Open("postgres", psqlInfo)
-
 	if err != nil {
-		log.Fatalf("Failed to open database connection: %v", err)
+		return fmt.Errorf("failed to open database connection: %w", err)
 	}
-
 	if err := db.Ping(); err != nil {
-		log.Fatalf("Failed to ping database: %v", err)
+		return fmt.Errorf("failed to ping database: %w", err)
 	}
-
 	DbConnection = db
+	return nil
 }
 
-func Ping() {
+func Ping() error {
 	if DbConnection == nil {
-		log.Fatalf("No database connection established")
+		return fmt.Errorf("no database connection established")
 	}
 	if err := DbConnection.Ping(); err != nil {
-		log.Fatalf("Failed to ping database: %v", err)
+		return fmt.Errorf("failed to ping database: %w", err)
 	}
 	fmt.Println("Connection Success")
+	return nil
 }
 
-func Close() {
+func Close() error {
 	if DbConnection == nil {
-		log.Fatalf("No database connection established")
+		return fmt.Errorf("no database connection established")
 	}
 	if err := DbConnection.Close(); err != nil {
-		log.Fatalf("Failed to close database connection: %v", err)
+		return fmt.Errorf("failed to close database connection: %w", err)
 	}
+	return nil
 }
 
-func Exec(query string) {
+func Exec(query string) error {
 	if DbConnection == nil {
-		log.Fatalf("No database connection established")
+		return fmt.Errorf("no database connection established")
 	}
 	if _, err := DbConnection.Exec(query); err != nil {
-		log.Fatalf("Failed to execute query: %v", err)
+		return fmt.Errorf("failed to execute query: %w", err)
 	}
 	fmt.Println("Query executed successfully")
+	return nil
 }
 
-func FileExec(filename string) {
+func FileExec(filename string) error {
 	if DbConnection == nil {
-		log.Fatalf("No database connection established")
+		return fmt.Errorf("no database connection established")
 	}
 	file, err := os.ReadFile(filename)
 	if err != nil {
-		log.Fatalf("Failed to read SQL file: %v", err)
+		return fmt.Errorf("failed to read SQL file: %w", err)
 	}
-
 	requests := strings.Split(string(file), ";")
 	for _, request := range requests {
 		request = strings.TrimSpace(request)
@@ -76,20 +75,21 @@ func FileExec(filename string) {
 			continue
 		}
 		if _, err := DbConnection.Exec(request); err != nil {
-			log.Fatalf("Failed to execute command: %v", err)
+			return fmt.Errorf("failed to execute command: %w", err)
 		}
 	}
 	fmt.Println("SQL file executed successfully")
+	return nil
 }
 
 func quoteIdentifier(name string) string { return pq.QuoteIdentifier(name) }
 func quoteLiteral(s string) string       { return pq.QuoteLiteral(s) }
 
-func validatePermissions(permissions string) string {
+func validatePermissions(permissions string) (string, error) {
 	for _, r := range permissions {
 		if !((r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || r == ' ' || r == ',' || r == '_') {
-			log.Fatalf("invalid permissions: %q", permissions)
+			return "", fmt.Errorf("invalid permissions: %q", permissions)
 		}
 	}
-	return permissions
+	return permissions, nil
 }

--- a/cmd/psql/database.go
+++ b/cmd/psql/database.go
@@ -1,15 +1,11 @@
 package psql
 
-import (
-	"fmt"
-	"log"
-)
+import "fmt"
 
-func ListDatabases() {
-	query := "SELECT datname FROM pg_catalog.pg_database;"
-	rows, err := DbConnection.Query(query)
+func ListDatabases() error {
+	rows, err := DbConnection.Query("SELECT datname FROM pg_catalog.pg_database;")
 	if err != nil {
-		log.Fatalf("Failed to execute query: %v", err)
+		return fmt.Errorf("failed to execute query: %w", err)
 	}
 	defer rows.Close()
 
@@ -17,25 +13,23 @@ func ListDatabases() {
 	for rows.Next() {
 		var database string
 		if err := rows.Scan(&database); err != nil {
-			log.Fatalf("Failed to scan row: %v", err)
+			return fmt.Errorf("failed to scan row: %w", err)
 		}
 		databases = append(databases, database)
 	}
-
 	if err := rows.Err(); err != nil {
-		log.Fatalf("Failed to iterate over rows: %v", err)
+		return fmt.Errorf("failed to iterate over rows: %w", err)
 	}
-
 	for _, database := range databases {
 		fmt.Println(database)
 	}
+	return nil
 }
 
-func ListTables() {
-	query := "SELECT tablename FROM pg_catalog.pg_tables;"
-	rows, err := DbConnection.Query(query)
+func ListTables() error {
+	rows, err := DbConnection.Query("SELECT tablename FROM pg_catalog.pg_tables;")
 	if err != nil {
-		log.Fatalf("Failed to execute query: %v", err)
+		return fmt.Errorf("failed to execute query: %w", err)
 	}
 	defer rows.Close()
 
@@ -43,32 +37,31 @@ func ListTables() {
 	for rows.Next() {
 		var table string
 		if err := rows.Scan(&table); err != nil {
-			log.Fatalf("Failed to scan row: %v", err)
+			return fmt.Errorf("failed to scan row: %w", err)
 		}
 		tables = append(tables, table)
 	}
-
 	if err := rows.Err(); err != nil {
-		log.Fatalf("Failed to iterate over rows: %v", err)
+		return fmt.Errorf("failed to iterate over rows: %w", err)
 	}
-
 	for _, table := range tables {
 		fmt.Println(table)
 	}
+	return nil
 }
 
-func CreateDatabase(database string) {
+func CreateDatabase(database string) error {
 	if _, err := DbConnection.Exec("CREATE DATABASE " + quoteIdentifier(database) + ";"); err != nil {
-		log.Printf("Database couldn't be created: %v", err)
-		return
+		return fmt.Errorf("failed to create database: %w", err)
 	}
 	fmt.Println("Database created successfully")
+	return nil
 }
 
-func DeleteDatabase(database string) {
+func DeleteDatabase(database string) error {
 	if _, err := DbConnection.Exec("DROP DATABASE " + quoteIdentifier(database) + ";"); err != nil {
-		log.Printf("Database couldn't be deleted: %v", err)
-		return
+		return fmt.Errorf("failed to delete database: %w", err)
 	}
 	fmt.Println("Database deleted successfully")
+	return nil
 }

--- a/cmd/psql/permission.go
+++ b/cmd/psql/permission.go
@@ -1,42 +1,55 @@
 package psql
 
-import (
-	"fmt"
-	"log"
-)
+import "fmt"
 
-func GrantPermissions(database, username, permissions string) {
-	query := "GRANT " + validatePermissions(permissions) + " ON DATABASE " + quoteIdentifier(database) + " TO " + quoteIdentifier(username) + ";"
+func GrantPermissions(database, username, permissions string) error {
+	perm, err := validatePermissions(permissions)
+	if err != nil {
+		return err
+	}
+	query := "GRANT " + perm + " ON DATABASE " + quoteIdentifier(database) + " TO " + quoteIdentifier(username) + ";"
 	if _, err := DbConnection.Exec(query); err != nil {
-		log.Printf("Permission couldn't be added: %v", err)
-		return
+		return fmt.Errorf("failed to grant permissions: %w", err)
 	}
 	fmt.Println("Permission added successfully")
+	return nil
 }
 
-func RevokePermissions(database, username, permissions string) {
-	query := "REVOKE " + validatePermissions(permissions) + " ON DATABASE " + quoteIdentifier(database) + " FROM " + quoteIdentifier(username) + ";"
+func RevokePermissions(database, username, permissions string) error {
+	perm, err := validatePermissions(permissions)
+	if err != nil {
+		return err
+	}
+	query := "REVOKE " + perm + " ON DATABASE " + quoteIdentifier(database) + " FROM " + quoteIdentifier(username) + ";"
 	if _, err := DbConnection.Exec(query); err != nil {
-		log.Printf("Permission couldn't be revoked: %v", err)
-		return
+		return fmt.Errorf("failed to revoke permissions: %w", err)
 	}
 	fmt.Println("Permission revoked successfully")
+	return nil
 }
 
-func GrantTablePermissions(table, username, permissions string) {
-	query := "GRANT " + validatePermissions(permissions) + " ON " + quoteIdentifier(table) + " TO " + quoteIdentifier(username) + ";"
+func GrantTablePermissions(table, username, permissions string) error {
+	perm, err := validatePermissions(permissions)
+	if err != nil {
+		return err
+	}
+	query := "GRANT " + perm + " ON " + quoteIdentifier(table) + " TO " + quoteIdentifier(username) + ";"
 	if _, err := DbConnection.Exec(query); err != nil {
-		log.Printf("Permission couldn't be added: %v", err)
-		return
+		return fmt.Errorf("failed to grant table permissions: %w", err)
 	}
 	fmt.Println("Permission added successfully")
+	return nil
 }
 
-func RevokeTablePermissions(table, username, permissions string) {
-	query := "REVOKE " + validatePermissions(permissions) + " ON " + quoteIdentifier(table) + " FROM " + quoteIdentifier(username) + ";"
+func RevokeTablePermissions(table, username, permissions string) error {
+	perm, err := validatePermissions(permissions)
+	if err != nil {
+		return err
+	}
+	query := "REVOKE " + perm + " ON " + quoteIdentifier(table) + " FROM " + quoteIdentifier(username) + ";"
 	if _, err := DbConnection.Exec(query); err != nil {
-		log.Printf("Permission couldn't be revoked: %v", err)
-		return
+		return fmt.Errorf("failed to revoke table permissions: %w", err)
 	}
 	fmt.Println("Permission revoked successfully")
+	return nil
 }

--- a/cmd/psql/user.go
+++ b/cmd/psql/user.go
@@ -1,15 +1,11 @@
 package psql
 
-import (
-	"fmt"
-	"log"
-)
+import "fmt"
 
-func ListUsers() {
-	query := "SELECT usename AS user FROM pg_catalog.pg_user;"
-	rows, err := DbConnection.Query(query)
+func ListUsers() error {
+	rows, err := DbConnection.Query("SELECT usename AS user FROM pg_catalog.pg_user;")
 	if err != nil {
-		log.Fatalf("Failed to execute query: %v", err)
+		return fmt.Errorf("failed to execute query: %w", err)
 	}
 	defer rows.Close()
 
@@ -17,43 +13,42 @@ func ListUsers() {
 	for rows.Next() {
 		var user string
 		if err := rows.Scan(&user); err != nil {
-			log.Fatalf("Failed to scan row: %v", err)
+			return fmt.Errorf("failed to scan row: %w", err)
 		}
 		users = append(users, user)
 	}
-
 	if err := rows.Err(); err != nil {
-		log.Fatalf("Failed to iterate over rows: %v", err)
+		return fmt.Errorf("failed to iterate over rows: %w", err)
 	}
-
 	for _, user := range users {
 		fmt.Println(user)
 	}
+	return nil
 }
 
-func CreateUser(username, password string) {
+func CreateUser(username, password string) error {
 	query := "CREATE USER " + quoteIdentifier(username) + " WITH PASSWORD " + quoteLiteral(password) + ";"
 	if _, err := DbConnection.Exec(query); err != nil {
-		log.Printf("User couldn't be created: %v", err)
-		return
+		return fmt.Errorf("failed to create user: %w", err)
 	}
 	fmt.Println("User created successfully")
+	return nil
 }
 
-func DeleteUser(username string) {
+func DeleteUser(username string) error {
 	query := "DROP USER " + quoteIdentifier(username) + ";"
 	if _, err := DbConnection.Exec(query); err != nil {
-		log.Printf("User couldn't be deleted: %v", err)
-		return
+		return fmt.Errorf("failed to delete user: %w", err)
 	}
 	fmt.Println("User deleted successfully")
+	return nil
 }
 
-func ChangeUserPassword(username, newPassword string) {
+func ChangeUserPassword(username, newPassword string) error {
 	query := "ALTER USER " + quoteIdentifier(username) + " WITH PASSWORD " + quoteLiteral(newPassword) + ";"
 	if _, err := DbConnection.Exec(query); err != nil {
-		log.Printf("Password couldn't be changed: %v", err)
-		return
+		return fmt.Errorf("failed to change user password: %w", err)
 	}
 	fmt.Println("Password changed successfully")
+	return nil
 }


### PR DESCRIPTION
All psql and mysql driver functions now return error. CLI callers in cmd/functions/db/ and batch.go handle errors at the boundary with fmt.Fprintf+os.Exit(1). batch.go uses exitOnErr to reduce per-call boilerplate.